### PR TITLE
[SYAL-2325] Remove "+" at LastOnline(+UTC) property.

### DIFF
--- a/src/main/java/com/avispl/symphony/dal/infrastructure/management/appspace/types/aggregated/GeneralProperty.java
+++ b/src/main/java/com/avispl/symphony/dal/infrastructure/management/appspace/types/aggregated/GeneralProperty.java
@@ -18,7 +18,7 @@ public enum GeneralProperty {
 	GROUP_NAME("GroupName"),
 	STATUS("Status"),
 	APP_VERSION("AppVersion"),
-	LAST_ONLINE("LastOnline(+UTC)"),
+	LAST_ONLINE("LastOnline(UTC)"),
 	TAGS("Tags"),
 	LICENSES("Licenses"),
 	CHANNEL_NAME("ChannelName"),


### PR DESCRIPTION
[SYAL-2325] The API error is displayed instead of the Login error when incorrect credentials are set
- Remove "+" at LastOnline(+UTC) property

[SYAL-2325]: https://avi-spl.atlassian.net/browse/SYAL-2325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ